### PR TITLE
Fix unterminated json in de_de lang file

### DIFF
--- a/src/main/resources/assets/lambdynlights/lang/de_de.json
+++ b/src/main/resources/assets/lambdynlights/lang/de_de.json
@@ -10,7 +10,7 @@
   "lambdynlights.tooltip.block_entities": "Schaltet dynamische Beleuchtung für Blockobjekte ein.",
   "lambdynlights.tooltip.creeper_lighting": "Ändert das Verhalten der dynamische Beleuchtung bei Creepern\n- %s schaltet dieses aus.\n- %s: konstante Beleuchtung durch explodierende Creepers.\n- %s: Zunehmende Beleuchtung durch explodierende Creepers.",
   "lambdynlights.tooltip.entities": "Aktiviert die dynamische Beleuchtung von Objekten. (Spielerbeleuchtung ist immer aktiviert)",
-  "lambdynlights.tooltip.mode.1": "Aktiviert dynamische Beleuchtung. Wenn aktiv, wird z. B. ein Spieler, der eine Fackel hält, die Umgebung beleuchten."
+  "lambdynlights.tooltip.mode.1": "Aktiviert dynamische Beleuchtung. Wenn aktiv, wird z. B. ein Spieler, der eine Fackel hält, die Umgebung beleuchten.",
   "lambdynlights.tooltip.mode.2": "%s und %s haben eine kleine Verzögerung, aber lösen weniger Lichtupdates aus.",
   "lambdynlights.tooltip.mode.3": "Mit %s sind die Bewegungen von Lichtquellen flüssig.",
   "lambdynlights.tooltip.tnt_lighting": "Ändert das Verhalten der dynamischer Beleuchtung von TNT.\n- %s schaltet dieses aus.\n- %s: konstante Beleuchtung.\n- %s steigende Beuleuchtung.",


### PR DESCRIPTION
Honestly don't know if that's worth a pr, but here it is.

This fixes a warning caused by unterminated json that was printed in the log files, however it didn't actually affect translations.
```
Skipped language file: lambdynlights:lang/de_de.json
  (com.google.gson.JsonSyntaxException: com.google.gson.stream.MalformedJsonException:
  Unterminated object at line 14 column 4 path $.lambdynlights.tooltip.mode.1)
```