### PR TITLE
Optimize hot methods maxDynamicLightLevel and updateTracking

### DIFF
--- a/src/main/java/dev/lambdaurora/lambdynlights/LambDynLights.java
+++ b/src/main/java/dev/lambdaurora/lambdynlights/LambDynLights.java
@@ -200,11 +200,11 @@ public class LambDynLights implements ClientModInitializer {
 			double dy = pos.getY() - lightSource.getDynamicLightY() + 0.5;
 			double dz = pos.getZ() - lightSource.getDynamicLightZ() + 0.5;
 
-			double distanceSqared = dx * dx + dy * dy + dz * dz;
+			double distanceSquared = dx * dx + dy * dy + dz * dz;
 			// 7.75 because else we would have to update more chunks and that's not a good idea.
 			// 15 (max range for blocks) would be too much and a bit cheaty.
-			if (distanceSqared <= MAX_RADIUS_SQUARED) {
-				double multiplier = 1.0 - Math.sqrt(distanceSqared) / MAX_RADIUS;
+			if (distanceSquared <= MAX_RADIUS_SQUARED) {
+				double multiplier = 1.0 - Math.sqrt(distanceSquared) / MAX_RADIUS;
 				double lightLevel = multiplier * (double) luminance;
 				if (lightLevel > currentLightLevel) {
 					return lightLevel;

--- a/src/main/java/dev/lambdaurora/lambdynlights/LambDynLights.java
+++ b/src/main/java/dev/lambdaurora/lambdynlights/LambDynLights.java
@@ -52,7 +52,7 @@ import java.util.function.Predicate;
 public class LambDynLights implements ClientModInitializer {
 	public static final String NAMESPACE = "lambdynlights";
 	private static final double MAX_RADIUS = 7.75;
-	private static final double MAX_RADIUS_SQUARED = 60.0625;
+	private static final double MAX_RADIUS_SQUARED = MAX_RADIUS * MAX_RADIUS;
 	private static LambDynLights INSTANCE;
 	public final Logger logger = LogManager.getLogger(NAMESPACE);
 	public final DynamicLightsConfig config = new DynamicLightsConfig(this);


### PR DESCRIPTION
maxDynamicLightLevel and updateTracking are two of the hottest methods in LambDynamicLights. This makes it worthwhile to do some micro-optimizations.

Due to randomness (and lack of patience from my part for long JFR recordings) I have a hard time telling the effects of this. A rough estimate is that it lowers the time spent in these methods by 5-10%, but it is a bit hard to tell. (Unfortunately I tested this without the nightconfig patch, so the issues from nightconfig tends to shadow these improvements).