### PR TITLE
Compatibility for 1.18 snapshots

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.9.45'
+    id 'fabric-loom' version '0.9-SNAPSHOT'
     id 'io.github.juuxel.loom-quiltflower' version '1.3.0'
     id 'java-library'
     id 'maven-publish'

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,11 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.17.1
-yarn_mappings=31
-loader_version=0.11.6
+minecraft_version=21w44a
+yarn_mappings=1
+loader_version=0.11.7
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-fabric_api_version=0.37.1+1.17
+fabric_api_version=0.41.4+1.18
 
 # Mod Properties
 mod_version = 2.1.0
@@ -17,5 +17,5 @@ modrinth_id=yBW8D80W
 
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-spruceui_version=3.2.0+1.17
-modmenu_version=2.0.4
+spruceui_version=3.3.0+1.17
+modmenu_version=3.0.0

--- a/src/main/java/dev/lambdaurora/lambdynlights/mixin/lightsource/BlockEntityMixin.java
+++ b/src/main/java/dev/lambdaurora/lambdynlights/mixin/lightsource/BlockEntityMixin.java
@@ -29,7 +29,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import javax.annotation.Nullable;
+//import javax.annotation.Nullable;
 
 @Mixin(BlockEntity.class)
 public abstract class BlockEntityMixin implements DynamicLightSource {
@@ -38,7 +38,7 @@ public abstract class BlockEntityMixin implements DynamicLightSource {
 	protected BlockPos pos;
 
 	@Shadow
-	@Nullable
+//	@Nullable
 	protected World world;
 
 	@Shadow


### PR DESCRIPTION
You might also create a 1.18 branch, if you merge it.

javax made problems for me so I disabled the Nullable annotation.
Should build using java 16 and gradle.