### PR TITLE
Fixed lambdynamiclightconfig.java on ATlauncher

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/dev/lambdaurora/lambdynlights/DynamicLightsConfig.java
+++ b/src/main/java/dev/lambdaurora/lambdynlights/DynamicLightsConfig.java
@@ -19,6 +19,7 @@ import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.text.Text;
 import org.jetbrains.annotations.NotNull;
 
+import net.fabricmc.loader.api.FabricLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -38,7 +39,7 @@ public class DynamicLightsConfig {
 	private static final ExplosiveLightingMode DEFAULT_CREEPER_LIGHTING_MODE = ExplosiveLightingMode.SIMPLE;
 	private static final ExplosiveLightingMode DEFAULT_TNT_LIGHTING_MODE = ExplosiveLightingMode.OFF;
 
-	public static final Path CONFIG_FILE_PATH = Paths.get("config/lambdynlights.toml");
+	public static final Path CONFIG_FILE_PATH = FabricLoader.getInstance().getConfigDir().resolve("lambdynlights.toml");
 	protected final FileConfig config;
 	private final LambDynLights mod;
 	private DynamicLightsMode dynamicLightsMode;


### PR DESCRIPTION
Fixed lambdynlights config for all launchers and updated gradle to 8.1.1 to support fabric.

Instead of directly getting the path, control is handed over to fabric to accurately handle the location of the config file.

This was suggested by @philberber. This will fix Issue #151.