### PR TITLE
Fix Indium incompatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.4.+'
+	id 'fabric-loom' version '1.6.+'
 	id 'dev.yumi.gradle.licenser' version '1.1.+'
 	id 'java-library'
 	id 'maven-publish'
@@ -135,7 +135,8 @@ dependencies {
 		transitive = false
 	}
 
-	modRuntimeOnly "maven.modrinth:sodium:${project.sodium_version}"
+	modImplementation "maven.modrinth:sodium:${project.sodium_version}"
+	modImplementation "maven.modrinth:indium:${project.indium_version}"
 
 	shadow 'com.electronwill.night-config:core:3.6.6'
 	shadow 'com.electronwill.night-config:toml:3.6.6'

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,5 @@ curseforge_id=393442
 spruceui_version=5.0.3+1.20.2
 pridelib_version=1.2.0+1.19.4
 modmenu_version=9.0.0
-sodium_version=mc1.20.3-0.5.5
+sodium_version=mc1.20.4-0.5.8
+indium_version=1.0.31+mc1.20.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/dev/lambdaurora/lambdynlights/LambDynLightsCompat.java
+++ b/src/main/java/dev/lambdaurora/lambdynlights/LambDynLightsCompat.java
@@ -59,4 +59,8 @@ public final class LambDynLightsCompat {
 			}
 		}).orElse(false);
 	}
+
+	public static boolean isIndiumInstalled() {
+		return FabricLoader.getInstance().isModLoaded("indium");
+	}
 }

--- a/src/main/java/dev/lambdaurora/lambdynlights/LambDynLightsMixinPlugin.java
+++ b/src/main/java/dev/lambdaurora/lambdynlights/LambDynLightsMixinPlugin.java
@@ -37,6 +37,9 @@ public class LambDynLightsMixinPlugin implements IMixinConfigPlugin {
 		this.conditionalMixins.put("dev.lambdaurora.lambdynlights.mixin.sodium.ArrayLightDataCacheMixin", sodium05XInstalled);
 		this.conditionalMixins.put("dev.lambdaurora.lambdynlights.mixin.sodium.FlatLightPipelineMixin", sodium05XInstalled);
 		this.conditionalMixins.put("dev.lambdaurora.lambdynlights.mixin.sodium.LightDataAccessMixin", sodium05XInstalled);
+
+		boolean indiumInstalled = LambDynLightsCompat.isIndiumInstalled();
+		this.conditionalMixins.put("dev.lambdaurora.lambdynlights.mixin.indium.TerrainRenderContextMixin", indiumInstalled);
 	}
 
 	@Override

--- a/src/main/java/dev/lambdaurora/lambdynlights/mixin/indium/TerrainRenderContextMixin.java
+++ b/src/main/java/dev/lambdaurora/lambdynlights/mixin/indium/TerrainRenderContextMixin.java
@@ -15,6 +15,7 @@ import dev.lambdaurora.lambdynlights.LambDynLights;
 import link.infra.indium.renderer.mesh.MutableQuadViewImpl;
 import link.infra.indium.renderer.render.AbstractBlockRenderContext;
 import link.infra.indium.renderer.render.TerrainRenderContext;
+import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
@@ -22,6 +23,7 @@ import org.spongepowered.asm.mixin.injection.At;
 @Pseudo
 @Mixin(value = TerrainRenderContext.class, remap = false)
 public abstract class TerrainRenderContextMixin extends AbstractBlockRenderContext {
+	@Dynamic
 	@WrapOperation(method = "bufferQuad", at = @At(value = "INVOKE", target = "Llink/infra/indium/renderer/mesh/MutableQuadViewImpl;lightmap(I)I"), require = 0)
 	private int lambdynlights$getLightmap(MutableQuadViewImpl instance, int i, Operation<Integer> original) {
 		return LambDynLights.get().getLightmapWithDynamicLight(this.blockInfo.blockPos, original.call(instance, i));

--- a/src/main/java/dev/lambdaurora/lambdynlights/mixin/indium/TerrainRenderContextMixin.java
+++ b/src/main/java/dev/lambdaurora/lambdynlights/mixin/indium/TerrainRenderContextMixin.java
@@ -9,10 +9,8 @@
 
 package dev.lambdaurora.lambdynlights.mixin.indium;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import dev.lambdaurora.lambdynlights.LambDynLights;
-import link.infra.indium.renderer.mesh.MutableQuadViewImpl;
 import link.infra.indium.renderer.render.AbstractBlockRenderContext;
 import link.infra.indium.renderer.render.TerrainRenderContext;
 import org.spongepowered.asm.mixin.Dynamic;
@@ -24,8 +22,8 @@ import org.spongepowered.asm.mixin.injection.At;
 @Mixin(value = TerrainRenderContext.class, remap = false)
 public abstract class TerrainRenderContextMixin extends AbstractBlockRenderContext {
 	@Dynamic
-	@WrapOperation(method = "bufferQuad", at = @At(value = "INVOKE", target = "Llink/infra/indium/renderer/mesh/MutableQuadViewImpl;lightmap(I)I"), require = 0)
-	private int lambdynlights$getLightmap(MutableQuadViewImpl instance, int i, Operation<Integer> original) {
-		return LambDynLights.get().getLightmapWithDynamicLight(this.blockInfo.blockPos, original.call(instance, i));
+	@ModifyExpressionValue(method = "bufferQuad", at = @At(value = "INVOKE", target = "Llink/infra/indium/renderer/mesh/MutableQuadViewImpl;lightmap(I)I"), require = 0)
+	private int lambdynlights$getLightmap(int original) {
+		return LambDynLights.get().getLightmapWithDynamicLight(this.blockInfo.blockPos, original);
 	}
 }

--- a/src/main/java/dev/lambdaurora/lambdynlights/mixin/indium/TerrainRenderContextMixin.java
+++ b/src/main/java/dev/lambdaurora/lambdynlights/mixin/indium/TerrainRenderContextMixin.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2024 LambdAurora <email@lambdaurora.dev>
+ *
+ * This file is part of LambDynamicLights.
+ *
+ * Licensed under the MIT license. For more information,
+ * see the LICENSE file.
+ */
+
+package dev.lambdaurora.lambdynlights.mixin.indium;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import dev.lambdaurora.lambdynlights.LambDynLights;
+import link.infra.indium.renderer.mesh.MutableQuadViewImpl;
+import link.infra.indium.renderer.render.AbstractBlockRenderContext;
+import link.infra.indium.renderer.render.TerrainRenderContext;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Pseudo
+@Mixin(value = TerrainRenderContext.class, remap = false)
+public abstract class TerrainRenderContextMixin extends AbstractBlockRenderContext {
+	@WrapOperation(method = "bufferQuad", at = @At(value = "INVOKE", target = "Llink/infra/indium/renderer/mesh/MutableQuadViewImpl;lightmap(I)I"), require = 0)
+	private int lambdynlights$getLightmap(MutableQuadViewImpl instance, int i, Operation<Integer> original) {
+		return LambDynLights.get().getLightmapWithDynamicLight(this.blockInfo.blockPos, original.call(instance, i));
+	}
+}

--- a/src/main/resources/lambdynlights.mixins.json
+++ b/src/main/resources/lambdynlights.mixins.json
@@ -13,12 +13,13 @@
     "MinecraftClientMixin",
     "VideoOptionsScreenMixin",
     "WorldMixin",
+    "fabric.AoCalculatorMixin",
+    "indium.TerrainRenderContextMixin",
     "ltr.LilTaterBlockEntityMixin",
     "ltr.LilTaterBlocksMixin",
     "sodium.ArrayLightDataCacheMixin",
     "sodium.FlatLightPipelineMixin",
-    "sodium.LightDataAccessMixin",
-    "fabric.AoCalculatorMixin"
+    "sodium.LightDataAccessMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Issues: #185, #212

This PR creates a mixin into Indium's [`TerrainRenderContext#bufferQuad`](https://github.com/comp500/Indium/blob/1.20.x/stable/src/main/java/link/infra/indium/renderer/render/TerrainRenderContext.java#L83), making the quad light also use LDL's lightmap values, which solves both:
- flat side of doors and hoppers not dynamically lighting (#185)
- flat lighting not working (#199?)

With the nature of how this mixin works, it unfortunately requires a compile-time dependency on Indium, unless someone can figure out a way to avoid that entirely.