### PR TITLE
chore: Use dynamic name in Sodium Options GUI

### DIFF
--- a/src/main/java/dev/lambdaurora/lambdynlights/mixin/sodium/SodiumOptionsGuiMixin.java
+++ b/src/main/java/dev/lambdaurora/lambdynlights/mixin/sodium/SodiumOptionsGuiMixin.java
@@ -38,7 +38,7 @@ public class SodiumOptionsGuiMixin extends Screen {
 	@Dynamic
 	@Inject(method = "<init>", at = @At("RETURN"))
 	private void lambdynlights$onInit(Screen prevScreen, CallbackInfo ci) {
-		this.pages.add(this.lambDynLights = SodiumOptionPage.makeSodiumOptionPage(Text.literal("LambDynamicLights")));
+		this.pages.add(this.lambDynLights = SodiumOptionPage.makeSodiumOptionPage(Text.translatable("lambdynlights.menu.title")));
 	}
 
 	@Dynamic


### PR DESCRIPTION
This pull request makes the button label in the Sodium Options GUI translatable, improves localization support and enhances flexibility for language customization.

Previously, it was hardcoded as `LambDynamicLights`.
Now, it uses the `lambdynlights.menu.title` translation key, allowing users or resource packs to customize the button text via language files.